### PR TITLE
SECENG-1116: Require patched MLflow

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -195,7 +195,7 @@ dask-jobqueue==0.9.0
 dask-kubernetes==2022.9.0
 dask-yarn==0.9
 databricks-cli==0.18.0
-databricks-sdk==0.17.0
+databricks-sdk==0.47.0
 dataclasses-json==0.6.7
 datadog==0.51.0
 dataproperty==1.1.0
@@ -308,6 +308,7 @@ httplib2==0.22.0
 httptools==0.6.4
 httpx==0.28.1
 httpx-sse==0.4.0
+huey==3.3.4
 huggingface-hub==0.30.2
 humanfriendly==10.0
 humanize==4.12.3
@@ -397,7 +398,9 @@ mdurl==0.1.2
 methodtools==0.4.7
 mistune==3.1.3
 mixpanel==4.10.1
-mlflow==1.27.0
+mlflow==3.15.1
+mlflow-skinny==3.15.1
+mlflow-tracing==3.15.1
 mmh3==5.1.0
 modal==0.74.39
 more-itertools==10.7.0
@@ -484,6 +487,7 @@ polars==1.29.0
 portalocker==2.10.1
 posthog==4.0.1
 premailer==3.10.0
+prettytable==3.18.0
 prison==0.2.1
 progressbar2==4.5.0
 # -e examples/docs_projects/project_atproto_dashboard
@@ -588,6 +592,7 @@ shellingham==1.5.4
 sigtools==4.0.1
 simplejson==3.20.1
 six==1.17.0
+skops==0.14.0
 skein==0.8.2
 skl2onnx==1.18.0
 slack-sdk==3.35.0
@@ -700,7 +705,7 @@ virtualenv==20.30.0
 wandb==0.19.10
 watchdog==5.0.3
 watchfiles==1.0.5
-wcwidth==0.2.13
+wcwidth==0.8.2
 weaviate-client==4.14.1
 webcolors==24.11.1
 webencodings==0.5.1

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -7,7 +7,7 @@ import atexit
 import sys
 from itertools import islice
 from os import environ
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import mlflow
 from dagster import Field, Noneable, Permissive, StringSource, resource
@@ -16,6 +16,9 @@ from dagster._core.definitions.resource_definition import dagster_maintained_res
 from dagster._utils.backoff import backoff
 from mlflow.entities.run_status import RunStatus
 from mlflow.exceptions import MlflowException
+
+if TYPE_CHECKING:
+    from mlflow.entities import Run
 
 CONFIG_SCHEMA = {
     "experiment_name": Field(StringSource, is_required=True, description="MlFlow experiment name."),
@@ -143,20 +146,24 @@ class MlFlow(metaclass=MlflowMeta):
         dagster_run_id = dagster_run_id or self.dagster_run_id
         if experiment:
             # Check if a run with this dagster run id has already been started
-            # in mlflow, will get an empty dataframe if not.
+            # in mlflow, will get an empty list if not.
             # Note: Search requests have a lower rate limit than others, so we
             # need to limit/retry searches where possible.
-            current_run_df = backoff(
-                mlflow.search_runs,
-                retry_on=(MlflowException,),
-                kwargs={
-                    "experiment_ids": [experiment.experiment_id],
-                    "filter_string": f"tags.dagster_run_id='{dagster_run_id}'",
-                },
-                max_retries=3,
+            current_runs = cast(
+                "list[Run]",
+                backoff(
+                    mlflow.search_runs,
+                    retry_on=(MlflowException,),
+                    kwargs={
+                        "experiment_ids": [experiment.experiment_id],
+                        "filter_string": f"tags.dagster_run_id='{dagster_run_id}'",
+                        "output_format": "list",
+                    },
+                    max_retries=3,
+                ),
             )
-            if not current_run_df.empty:
-                return current_run_df.run_id.values[0]
+            if current_runs:
+                return current_runs[0].info.run_id
 
     def _set_active_run(self, run_id=None):
         """This method sets the active run to be that of the specified
@@ -184,7 +191,7 @@ class MlFlow(metaclass=MlflowMeta):
             )
         except Exception as ex:
             run = mlflow.active_run()
-            if "is already active" not in str(ex):
+            if run is None or "is already active" not in str(ex):
                 raise (ex)
             self.log.info(f"Run with id {run.info.run_id} is already active.")
 

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -10,7 +10,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import mlflow
-import pandas as pd
 import pytest
 from dagster import op
 from dagster._core.definitions.decorators.job_decorator import job
@@ -234,34 +233,34 @@ def test_set_all_tags(mock_mlflow_set_tags, context):
     mock_mlflow_set_tags.assert_called_once_with(tags)
 
 
-@pytest.mark.parametrize("run_df", [pd.DataFrame(), pd.DataFrame(data={"run_id": ["100"]})])
+@pytest.mark.parametrize("runs", [[], [MagicMock(info=MagicMock(run_id="100"))]])
 @pytest.mark.parametrize(
     "experiment", [None, MagicMock(experiment_id="1"), MagicMock(experiment_id="lol")]
 )
-def test_get_current_run_id(context, experiment, run_df):
+def test_get_current_run_id(context, experiment, runs):
     with patch.object(MlFlow, "_setup"):
         # Given: an initialization of the mlflow object
         mlf = MlFlow(context)
 
-    with patch("mlflow.search_runs", return_value=run_df):
+    with patch("mlflow.search_runs", return_value=runs):
         # when: _get_current_run_id is called
         run_id = mlf._get_current_run_id(experiment=experiment)  # noqa: SLF001
     # Then: the run_id id provided is the same as what was provided
-    if not run_df.empty:
-        assert run_id == run_df.run_id.values[0]
+    if runs:
+        assert run_id == runs[0].info.run_id
     else:
         assert run_id is None
 
 
 def test_get_current_run_id_with_one_mlflow_error(context):
     experiment = MagicMock(experiment_id="1")
-    run_df = pd.DataFrame(data={"run_id": ["100"]})
+    runs = [MagicMock(info=MagicMock(run_id="100"))]
 
     with patch.object(MlFlow, "_setup"):
         # Given: an initialization of the mlflow object
         mlf = MlFlow(context)
 
-    # Simulate MlflowException being raised once, then return the run_df
+    # Simulate MlflowException being raised once, then return the runs
     with patch(
         "mlflow.search_runs",
         side_effect=[
@@ -269,14 +268,14 @@ def test_get_current_run_id_with_one_mlflow_error(context):
                 "Max retries exceeded with url: /api/2.0/mlflow/runs/search (Caused by ResponseError('too many 429 error "
                 "responses')"
             ),
-            run_df,
+            runs,
         ],
     ):
         # when: _get_current_run_id is called
         run_id = mlf._get_current_run_id(experiment=experiment)  # noqa: SLF001
 
     # Then: the run_id id provided is the same as what was provided
-    assert run_id == run_df.run_id.values[0]
+    assert run_id == runs[0].info.run_id
 
 
 @patch("atexit.unregister")
@@ -420,11 +419,15 @@ def test_execute_op_with_mlflow_resource():
     @op(required_resource_keys={"mlflow"})
     def op1(_):
         mlflow.log_params(params)
-        run_id_holder["op1_run_id"] = mlflow.active_run().info.run_id
+        active_run = mlflow.active_run()
+        assert active_run is not None
+        run_id_holder["op1_run_id"] = active_run.info.run_id
 
     @op(required_resource_keys={"mlflow"})
     def op2(_, _arg1):
-        run_id_holder["op2_run_id"] = mlflow.active_run().info.run_id
+        active_run = mlflow.active_run()
+        assert active_run is not None
+        run_id_holder["op2_run_id"] = active_run.info.run_id
 
     @job(resource_defs={"mlflow": mlflow_tracking})
     def mlf_job():

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
-        "mlflow",
+        "mlflow>=3.15.0",
         "pandas",
         "protobuf!=5.29.0",  # https://github.com/protocolbuffers/protobuf/issues/19430
     ],


### PR DESCRIPTION
## Summary & Motivation

Remediates CVE-2026-64849 / GHSA-7gwp-5pfp-969j, an SSRF vulnerability affecting MLflow versions before 3.15.0.

- require MLflow 3.15.0 or newer in `dagster-mlflow`
- update the master Pyright pins to MLflow 3.15.1 and its required dependency delta
- use MLflow's list search output for compatibility with the patched API and harden active-run handling

## How I Tested These Changes

- `pytest python_modules/libraries/dagster-mlflow/dagster_mlflow_tests -q` (59 passed)
- targeted Pyright: 9 files, 0 errors, 0 warnings
- Ruff 0.11.5 check and format check
- rebuilt the master Pyright environment from the minimized pinned dependency set
